### PR TITLE
Added parenthesis around port config before the integer type cast to …

### DIFF
--- a/src/Bootstrap/CreateDatabaseConnection.php
+++ b/src/Bootstrap/CreateDatabaseConnection.php
@@ -24,7 +24,7 @@ class CreateDatabaseConnection
             'driver' => 'mysql',
             'url' => '',
             'host' => $config['hostname'] ?? env('DB_HOST', '127.0.0.1'),
-            'port' => (int) $config['port'] ?? env('DB_PORT', 3306),
+            'port' => (int) ($config['port'] ?? env('DB_PORT', 3306)),
             'database' => $config['database'] ?? env('EE_DB_DATABASE', 'expressionengine'),
             'username' => $config['username'] ?? env('DB_USERNAME', 'forge'),
             'password' => $config['password'] ?? env('DB_PASSWORD', ''),


### PR DESCRIPTION
The type cast was forcing the `$config['port']` from returning null if not set and causing an error during EE setup.
![image](https://github.com/ExpressionEngine/Coilpack/assets/14264007/2f260088-6a64-4265-9b06-f02ed4258d2d)
