### PR TITLE
Fixed blank response header error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Generic fieldtype passes `content_id` along to core fieldtype handler and triggers `pre_process` hook.
 - Error checking and handling for GraphQL compatible fieldtypes
 - Trigger `core_boot` hook during GraphQL requests
+- Handling of blank headers in HTTP responses
 
 ## [1.1.2] - 2023-07-27
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -259,7 +259,10 @@ class Response
         $headers = array_reduce(headers_list(), function ($carry, $header) use ($exclude) {
             $pieces = explode(': ', $header);
             if (count($pieces) !== 2) {
-                return $carry;
+                $pieces = [
+                    rtrim($pieces[0], ':'),
+                    ''
+                ];
             }
             if (! in_array(strtolower($pieces[0]), $exclude)) {
                 $carry[$pieces[0]] = $pieces[1];

--- a/src/Response.php
+++ b/src/Response.php
@@ -257,19 +257,16 @@ class Response
         // Transform headers that have already been set on the request
         // to the correct format ["header_name" => "value"]
         $headers = array_reduce(headers_list(), function ($carry, $header) use ($exclude) {
-            $pieces = explode(': ', $header);
-            if (count($pieces) !== 2) {
-                $pieces = [
-                    rtrim($pieces[0], ':'),
-                    ''
-                ];
-            }
-            if (! in_array(strtolower($pieces[0]), $exclude)) {
-                $carry[$pieces[0]] = $pieces[1];
+            $pieces = explode(':', $header);
+            $name = trim($pieces[0]);
+            $value = $pieces[1] ?? '';
+
+            if (! in_array(strtolower($name), $exclude)) {
+                $carry[$name] = trim($value);
             }
 
             // Remove the already set header to avoid duplicates in the response
-            header_remove($pieces[0]);
+            header_remove($name);
 
             return $carry;
         }, []);

--- a/src/Response.php
+++ b/src/Response.php
@@ -258,7 +258,9 @@ class Response
         // to the correct format ["header_name" => "value"]
         $headers = array_reduce(headers_list(), function ($carry, $header) use ($exclude) {
             $pieces = explode(': ', $header);
-
+            if (count($pieces) !== 2) {
+                return $carry;
+            }
             if (! in_array(strtolower($pieces[0]), $exclude)) {
                 $carry[$pieces[0]] = $pieces[1];
             }


### PR DESCRIPTION
I found an issue when Coilpack processes the response headers.

The headers are split into an array with explode. If the header is blank, just contains the `header-name:` then the response will attempt to access the value, array key 1, resulting in undefined array key error as it does not exist. Also the blank header name, array key 0, still has the original header names colon suffixed.

I simply removed the trailing colon from the name and set array key 1 to an empty string when the header array does not contain two elements.