### PR TITLE
Fixed problem with header fix when header has colons in the content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bug in transforming headers for Laravel response
+
 ## [1.2.1] - 2023-11-28
 
 ### Fixed

--- a/src/Core.php
+++ b/src/Core.php
@@ -79,7 +79,7 @@ class Core
         $headers = $this->getRestrictedProperty($response, 'headers');
 
         if ($body == '') {
-            return Response::fromOutput($status);
+            return (new Response)->fromOutput($status);
         }
 
         return new \Illuminate\Http\Response($body, $status, $headers);

--- a/src/Response.php
+++ b/src/Response.php
@@ -257,9 +257,9 @@ class Response
         // Transform headers that have already been set on the request
         // to the correct format ["header_name" => "value"]
         $headers = array_reduce(headers_list(), function ($carry, $header) use ($exclude) {
-            $pieces = explode(':', $header);
+            $pieces = explode(':', $header, 2);
             $name = trim(array_shift($pieces));
-            $value = ! empty($pieces) ? implode('', $pieces) : '';
+            $value = is_array($pieces) ? implode(':', $pieces) : '';
 
             if (! in_array(strtolower($name), $exclude)) {
                 $carry[$name] = trim($value);

--- a/src/Response.php
+++ b/src/Response.php
@@ -258,9 +258,8 @@ class Response
         // to the correct format ["header_name" => "value"]
         $headers = array_reduce(headers_list(), function ($carry, $header) use ($exclude) {
             $pieces = explode(':', $header, 2);
-            $name = trim(array_shift($pieces));
-            $value = is_array($pieces) ? implode(':', $pieces) : '';
-
+            $name = $pieces[0];
+            $value = $pieces[1] ?? '';
             if (! in_array(strtolower($name), $exclude)) {
                 $carry[$name] = trim($value);
             }

--- a/src/Response.php
+++ b/src/Response.php
@@ -11,24 +11,25 @@ class Response
      * @param  int  $status
      * @return Illuminate\Http\Response
      */
-    public static function fromOutput($status = 200)
+    public function fromOutput($status = 200)
     {
         $output = ee()->output->final_output;
+        $response = ee('Response') ?: new \ExpressionEngine\Core\Response;
 
         // Generate No-Cache Headers
 
         if (ee()->config->item('send_headers') == 'y' && ee()->output->out_type != 'feed' && ee()->output->out_type != '404' && ee()->output->out_type != 'cp_asset') {
             ee()->output->set_status_header($status);
 
-            if (! ee('Response')->hasHeader('Expires')) {
+            if (! $response->hasHeader('Expires')) {
                 ee()->output->set_header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
             }
 
-            if (! ee('Response')->hasHeader('Last-Modified')) {
+            if (! $response->hasHeader('Last-Modified')) {
                 ee()->output->set_header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
             }
 
-            if (! ee('Response')->hasHeader('Pragma')) {
+            if (! $response->hasHeader('Pragma')) {
                 ee()->output->set_header('Pragma: no-cache');
             }
         }
@@ -38,19 +39,19 @@ class Response
 
         switch (ee()->output->out_type) {
             case 'webpage':
-                if (! ee('Response')->hasHeader('Content-Type')) {
+                if (! $response->hasHeader('Content-Type')) {
                     ee()->output->set_header('Content-Type: text/html; charset='.ee()->config->item('charset'));
                 }
 
                 break;
             case 'css':
-                if (! ee('Response')->hasHeader('Content-Type')) {
+                if (! $response->hasHeader('Content-Type')) {
                     ee()->output->set_header('Content-type: text/css');
                 }
 
                 break;
             case 'js':
-                if (! ee('Response')->hasHeader('Content-Type')) {
+                if (! $response->hasHeader('Content-Type')) {
                     ee()->output->set_header('Content-type: text/javascript');
                 }
                 ee()->output->enable_profiler = false;
@@ -62,7 +63,7 @@ class Response
 
                 break;
             case 'xml':
-                if (! ee('Response')->hasHeader('Content-Type')) {
+                if (! $response->hasHeader('Content-Type')) {
                     ee()->output->set_header('Content-Type: text/xml');
                 }
                 $output = trim($output);
@@ -257,15 +258,14 @@ class Response
         // Transform headers that have already been set on the request
         // to the correct format ["header_name" => "value"]
         $headers = array_reduce(headers_list(), function ($carry, $header) use ($exclude) {
-            $pieces = explode(':', $header, 2);
-            $name = $pieces[0];
-            $value = $pieces[1] ?? '';
-            if (! in_array(strtolower($name), $exclude)) {
-                $carry[$name] = trim($value);
+            $header = $this->parseHeader($header);
+
+            if (! in_array(strtolower($header->name), $exclude)) {
+                $carry[$header->name] = $header->value;
             }
 
             // Remove the already set header to avoid duplicates in the response
-            header_remove($name);
+            header_remove($header->name);
 
             return $carry;
         }, []);
@@ -273,15 +273,25 @@ class Response
         // Transform and set headers that have been assigned to the Output class
         // but not yet set on the request to be ["header_name" => "value"]
         foreach (ee()->output->headers as $row) {
-            $header = explode(': ', $row[0]);
+            $header = $this->parseHeader($row[0]);
             $replace = $row[1];
 
             // If this header has not already been set, or if we are replacing it set the value
-            if (! in_array(strtolower($header[0]), $exclude) && (! array_key_exists($header[0], $headers) || $replace)) {
-                $headers[$header[0]] = $header[1];
+            if (! in_array(strtolower($header->name), $exclude) && (! array_key_exists($header->name, $headers) || $replace)) {
+                $headers[$header->name] = $header->value;
             }
         }
 
         return new \Illuminate\Http\Response($output, $status, $headers);
+    }
+
+    protected function parseHeader($header)
+    {
+        $pieces = explode(':', $header, 2);
+
+        return (object) [
+            'name' => $pieces[0],
+            'value' => trim($pieces[1] ?? ''),
+        ];
     }
 }

--- a/tests/Core/ResponseTest.php
+++ b/tests/Core/ResponseTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Tests;
+namespace Tests\Core;
 
 use Expressionengine\Coilpack\Response;
+use Tests\TestCase;
 
 class ResponseTest extends TestCase
 {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests;
+
+use Expressionengine\Coilpack\Response;
+
+class ResponseTest extends TestCase
+{
+    public function test_parsing_headers_with_multiple_colons()
+    {
+        ee()->output->set_header('test: one:two:three');
+
+        $response = (new Response)->fromOutput();
+
+        $this->assertEquals($response->headers->get('Expires'), 'Mon, 26 Jul 1997 05:00:00 GMT');
+        $this->assertEquals($response->headers->get('test'), 'one:two:three');
+    }
+}

--- a/tests/fixtures/phpunit.xml
+++ b/tests/fixtures/phpunit.xml
@@ -8,6 +8,9 @@
          failOnRisky="false"
 >
     <testsuites>
+        <testsuite name="Core">
+            <directory suffix="Test.php">./tests/Core</directory>
+        </testsuite>
         <testsuite name="Fieldtypes">
             <directory suffix="Test.php">./tests/Fieldtype</directory>
         </testsuite>


### PR DESCRIPTION
I found that the header fix had an issue with content containing colons, such as dates.
I had a Set-Cookie header containing a date,
`Set-Cookie: exp_sessionid=xxxe; expires=Wed, 29 Nov 2023 13:24:20 GMT; Max-Age=3600; path=/; SameSite=Lax` 
which had the colons removed with the current fix, 
`Set-Cookie: exp_sessionid=823865ab553000096a9d85243f14f2c9b1c760ee; expires=Wed, 29 Nov 2023 132420 GMT; Max-Age=3600; path=/; SameSite=Lax`

I have simply limited the header explode to 2 elements and reverted the other changes.
