### PR TITLE
Adding fluent definition call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bug where ExpressionEngine CLI command proxy was not recognizing optional arguments
+
 ## [1.3.1] - 2024-04-24
 
 ### Fixed

--- a/src/Commands/EECliCommand.php
+++ b/src/Commands/EECliCommand.php
@@ -32,6 +32,7 @@ class EECliCommand extends Command
             // If we have a help flag we need to get out early so that it can be
             // handled by the ExpressionEngine Command and not by Symfony/Laravel
             if ($arg == '--help') {
+                $this->cli->info("Coilpack Usage: $this->signature");
                 return $this->handle();
             }
         }

--- a/src/Commands/EECliCommand.php
+++ b/src/Commands/EECliCommand.php
@@ -72,6 +72,8 @@ class EECliCommand extends Command
 
             return '{--'.$option.'=}';
         }, array_keys($options)));
+
+        $this->configureUsingFluentDefinition();
     }
 
     public function handle(): int


### PR DESCRIPTION
Addresses issue where `php artisan eecli` was failing to grab available options and handing them off to the EECLI command.

Example:

`php artisan eecli import:run --id=2` would fail because `id` is not an option for `eecli`.

This addresses that and adequately passes through. All props to @bryannielsen 